### PR TITLE
fixed 'fire_upon' method and it fixed our 'render' tests. didnt add  "H" or "X" yet

### DIFF
--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -7,6 +7,7 @@ attr_reader :coordinate,
     @coordinate = coordinate
     @ship = nil
     @fired_upon = false
+    #@render_value = ""
   end
 
   def empty?
@@ -23,7 +24,24 @@ attr_reader :coordinate,
 
   def fire_upon
     @fired_upon = true
-    !empty?
-    ship.hit
+    if !empty?
+      ship.hit
+    end
+    
   end
+
+  def render
+    if fired_upon? && empty?
+      "M"
+    else
+      empty?
+      "."
+    end
+  end
+
 end
+
+# ”.” if the cell has not been fired upon.
+# “M” if the cell has been fired upon and it does not contain a ship (the shot was a miss).
+# “H” if the cell has been fired upon and it contains a ship (the shot was a hit).
+# “X” if the cell has been fired upon and its ship has been sunk.

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -46,10 +46,25 @@ RSpec.describe Cell do
 
   describe "#fire_upon" do
     it "fires upon a cell" do
+      # require 'pry'; binding.pry
       cell.place_ship(cruiser)
       cell.fire_upon
       expect(cell.ship.health).to eq(2)
       expect(cell.fired_upon?).to eq(true)
+    end
+  end
+
+  describe "#render" do
+    let(:cell_1) {Cell.new("B4")}
+
+    it "renders a cell that hasn't been fired upon" do
+      expect(cell_1.render).to eq(".") 
+    end
+
+    it "fires upon an empty cell and misses" do
+      cell_1.fire_upon
+      expect(cell_1.render).to eq("M") 
+
     end
   end
 end
@@ -57,3 +72,46 @@ end
 
 
 
+# > cell_1 = Cell.new("B4")
+# # => #<Cell:0x00007f84f11df920...>
+
+# > cell_1.render
+# # => "."
+
+# > cell_1.fire_upon
+
+# > cell_1.render
+# # => "M"
+
+# > cell_2 = Cell.new("C3")
+# # => #<Cell:0x00007f84f0b29d10...>
+
+# > cruiser = Ship.new("Cruiser", 3)
+# # => #<Ship:0x00007f84f0ad4fb8...>
+
+# > cell_2.place_ship(cruiser)
+
+# > cell_2.render
+# # => "."
+
+# # Indicate that we want to show a ship with the optional argument
+# > cell_2.render(true)
+# # => "S"
+
+# > cell_2.fire_upon
+
+# > cell_2.render
+# # => "H"
+
+# > cruiser.sunk?
+# # => false
+
+# pry(main)> cruiser.hit
+
+# pry(main)> cruiser.hit
+
+# pry(main)> cruiser.sunk?
+# # => true
+
+# pry(main)> cell_2.render
+# # => "X"


### PR DESCRIPTION
I had to refactor the 'fire_upon' method by adding an 'if' bc when I did a pry in the spec file it wasnt registering that the cell had been fired uponn when it was empty. in effect, that made our 'render' tests pass once it was changed. 